### PR TITLE
Switch from deprecated HashTable (base) to BasicHashTable (hashtables).

### DIFF
--- a/anydbm.cabal
+++ b/anydbm.cabal
@@ -24,9 +24,9 @@ Exposed-Modules: Database.AnyDBM,
     Database.AnyDBM.MapDBM,
     Database.AnyDBM.StringDBM
 Extensions: ExistentialQuantification, OverlappingInstances, 
-   UndecidableInstances, CPP, FlexibleInstances, TypeSynonymInstances
+   UndecidableInstances, CPP, FlexibleInstances, TypeSynonymInstances, TypeFamilies
 Build-Depends: base,
-               mtl, MissingH>=1.0.0, containers
+               mtl, MissingH>=1.0.0, containers, hashtables
 GHC-Options: -O2
 
 Executable: runtests

--- a/src/Database/AnyDBM.hs
+++ b/src/Database/AnyDBM.hs
@@ -41,7 +41,7 @@ module Database.AnyDBM (-- * The AnyDBM class
 where
 import Prelude hiding (lookup)
 import System.IO
-import Data.HashTable
+import Data.HashTable.IO
 import Control.Exception
 import Data.List.Utils(strFromAL, strToAL)
 
@@ -160,7 +160,7 @@ strFromA :: AnyDBM a => a -> IO String
 strFromA h = do l <- toListA h 
                 return (strFromAL l)
 
-instance AnyDBM (HashTable String String) where
+instance BasicHashTable String String ~ hashtable => AnyDBM hashtable where
     insertA h k v = do delete h k
                        insert h k v
     deleteA = delete

--- a/src/Database/AnyDBM/StringDBM.hs
+++ b/src/Database/AnyDBM/StringDBM.hs
@@ -44,11 +44,11 @@ import Database.AnyDBM
 import System.IO
 import System.IO.HVFS
 import System.IO.HVIO
-import Data.HashTable
+import Data.HashTable.IO
 import Control.Concurrent.MVar
 
 {- | The type of the StringDBM instances. -}
-data StringDBM = forall a. HVFSOpenable a => StringDBM (MVar ()) (HashTable String String) IOMode a FilePath
+data StringDBM = forall a. HVFSOpenable a => StringDBM (MVar ()) (BasicHashTable String String) IOMode a FilePath
 
 {- | Opens a 'StringDBM' file.  Please note: only ReadMode, WriteMode,
 and ReadWriteMode are supported for the IOMode.  AppendMode is not supported. 
@@ -67,18 +67,18 @@ To work on your system's normal (real) filesystem, just specify
 openStringVDBM :: HVFSOpenable a => a -> FilePath -> IOMode -> IO StringDBM
 openStringVDBM _ _ AppendMode = fail "openStringDBM: AppendMode is not supported"
 openStringVDBM h fp ReadMode =
-    do ht <- new (==) hashString
+    do ht <- new
        lock <- newMVar ()
        vReadFile h fp >>= strToA ht
        return $ StringDBM lock ht ReadMode h fp
 openStringVDBM h fp WriteMode =
-    do ht <- new (==) hashString
+    do ht <- new
        lock <- newMVar ()
        return $ StringDBM lock ht WriteMode h fp
 openStringVDBM h fp ReadWriteMode =
     -- Nothing different to start with.  Later, we emulate WriteMode.
     -- Nothing is ever read after the object is created.
-    do ht <- new (==) hashString
+    do ht <- new
        lock <- newMVar ()
        d <- vDoesFileExist h fp
        if d
@@ -86,7 +86,7 @@ openStringVDBM h fp ReadWriteMode =
           else return ()
        return $ StringDBM lock ht WriteMode h fp
 
-g :: StringDBM -> HashTable String String
+g :: StringDBM -> BasicHashTable String String
 g (StringDBM _ ht _ _ _) = ht
 
 instance AnyDBM StringDBM where


### PR DESCRIPTION
Data.HashTable no longer exists in base as of GHC 7.8.
